### PR TITLE
chore: Firebase プロジェクトの指定を環境変数から具体的なプロジェクト名に変更

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": $FIREBASE_PROJECT
+    "default": "travis-ci-f841a"
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ deploy:
   skip_cleanup: true
   token:
     secure: $FIREBASE_TOKEN
-  project: $FIREBASE_PROJECT
+  project: "travis-ci-f841a"
   on:
     branch: develop


### PR DESCRIPTION
.firebaserc は環境変数を展開しないので (そのためパースエラーになっていた) 。
また、プロジェクト名を隠しておく理由も特にないので、そのまま指定することにした。